### PR TITLE
0.11.2

### DIFF
--- a/factions/common.resources
+++ b/factions/common.resources
@@ -16,7 +16,7 @@
 	<!-- Sub Machine Guns -->
 	<weapon key="km_sub_machine_gun.weapon" />
 	<weapon key="km_ump_45.weapon" />
-	<weapon key="p90.weapon" />
+	<weapon key="es_c90.weapon" />
 
 	<!-- Shotguns -->
 	<weapon key="leone_12_gauge_super.weapon" />

--- a/factions/counter_terrorist.resources
+++ b/factions/counter_terrorist.resources
@@ -16,7 +16,7 @@
 	<!-- Shotguns -->
 
 	<!-- Assault Rifles-->
-	<weapon key="maverick_m4A1_carbine.weapon" />
+	<weapon key="maverick_m4a1_carbine.weapon" />
 	<weapon key="bullpup.weapon" />
 	<weapon key="clarion_556.weapon" />
 

--- a/items/kevlar.carry_item
+++ b/items/kevlar.carry_item
@@ -37,9 +37,9 @@
         <inventory encumbrance="4" price="1" />
         <commonness value="0.0" in_stock="0" can_respawn_with="0" />
 
-	<!-- death -> wound -->
-        <modifier class="projectile_blast_result" input_character_state="death" output_character_state="wound" />
-        <modifier class="projectile_hit_result" input_character_state="death" output_character_state="wound" />
+	<!-- death -> stun -->
+        <modifier class="projectile_blast_result" input_character_state="death" output_character_state="stun" />
+        <modifier class="projectile_hit_result" input_character_state="death" output_character_state="stun" />
         <modifier class="speed" value="-0.05" />
     </carry_item>
 </carry_items>

--- a/items/kevlar_plus_helmet.carry_item
+++ b/items/kevlar_plus_helmet.carry_item
@@ -85,9 +85,9 @@
 
 	<!-- death or wound -> stun only -->
         <modifier class="projectile_blast_result" input_character_state="death" output_character_state="death" />
-        <modifier class="projectile_blast_result" input_character_state="wound" output_character_state="wound" />
-        <modifier class="projectile_hit_result" input_character_state="death" output_character_state="wound" />
-        <modifier class="projectile_hit_result" input_character_state="wound" output_character_state="wound" />
+        <modifier class="projectile_blast_result" input_character_state="wound" output_character_state="stun" />
+        <modifier class="projectile_hit_result" input_character_state="death" output_character_state="stun" />
+        <modifier class="projectile_hit_result" input_character_state="wound" output_character_state="stun" />
         <modifier class="speed" value="-0.08" />
     </carry_item>
 

--- a/maps/pvp1/objects.svg
+++ b/maps/pvp1/objects.svg
@@ -8060,16 +8060,16 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="8"
-     inkscape:cx="1143.4771"
-     inkscape:cy="952.12639"
+     inkscape:zoom="1"
+     inkscape:cx="941.12073"
+     inkscape:cy="977.89033"
      inkscape:document-units="px"
-     inkscape:current-layer="layer2"
+     inkscape:current-layer="layer16"
      showgrid="false"
      inkscape:window-width="1680"
      inkscape:window-height="951"
      inkscape:window-x="1050"
-     inkscape:window-y="336"
+     inkscape:window-y="399"
      inkscape:window-maximized="1"
      inkscape:snap-bbox="false"
      inkscape:object-nodes="true"
@@ -19422,18 +19422,6 @@ roof_cutout_texture = cutout.png; roof_cutout_texture_channel = 1; roof_cutout_t
            id="desc6099-8-7-4-5">height=3;</desc>
       </rect>
       <rect
-         style="fill:#007cff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:11.99999953, 11.99999953;stroke-dashoffset:4.59999986;display:inline;enable-background:new"
-         id="spawn1-3-7-8-5"
-         width="3.982286"
-         height="7.3961515"
-         x="1486.1505"
-         y="354.91714"
-         inkscape:label=""
-         transform="matrix(0.93488383,0.35495383,-0.35495383,0.93488383,0,0)">
-        <desc
-           id="desc7082-7-40-6-2">type = vehicle; key = humvee.vehicle;</desc>
-      </rect>
-      <rect
          style="fill:#0000ff;fill-opacity:1;stroke:none;display:inline;enable-background:new"
          id="rect4878-8-6-42-7-9-6-62-98"
          width="2.2977724"
@@ -19513,18 +19501,6 @@ roof_cutout_texture = cutout.png; roof_cutout_texture_channel = 1; roof_cutout_t
          inkscape:transform-center-y="-22.325767">
         <desc
            id="desc9788-45-3-6-1-6-7-2-09-4-7-2-82-2-4-2-6-7-2-6-4-4-7-9-6-9-0-8">type = vehicle; key = deco_car1_red.vehicle;</desc>
-      </rect>
-      <rect
-         style="fill:#007cff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:11.99999923, 11.99999923;stroke-dashoffset:4.59999977;display:inline;enable-background:new"
-         id="spawn1-3-7-8-5-1"
-         width="3.982286"
-         height="7.3961515"
-         x="-1102.4823"
-         y="774.89258"
-         inkscape:label=""
-         transform="matrix(0.02111231,-0.99977711,0.99977711,0.02111231,0,0)">
-        <desc
-           id="desc7082-7-40-6-2-7">type = vehicle; key = humvee.vehicle;</desc>
       </rect>
       <rect
          transform="matrix(-0.06102492,0.99813624,-0.99813624,-0.06102492,0,0)"
@@ -20064,6 +20040,20 @@ top_material = none;</desc>
          inkscape:transform-center-y="37.523669">
         <desc
            id="desc9788-45-3-6-1-6-7-2-09-4-7-2-82-2-4-7-1-4-7-2-2-9">type = vehicle; key = deco_car3_green.vehicle;</desc>
+      </rect>
+      <rect
+         transform="rotate(90.76769)"
+         inkscape:label=""
+         y="-772.21655"
+         x="1103.0469"
+         height="6.6684999"
+         width="5.7888808"
+         id="spawn2_8-1-0"
+         style="display:inline;fill:#0000ff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:4.00000126, 4.00000126;stroke-dashoffset:7.00000238;stroke-opacity:1;enable-background:new"
+         inkscape:transform-center-x="-0.15403042"
+         inkscape:transform-center-y="-0.085528379">
+        <desc
+           id="desc9788-45-3-6-1-6-7-2-09-4-7-2-82-2-4-4-2-4-7-5-1-7-0-2-6-0-2-5">type = vehicle; key = deco_car2_blue.vehicle;</desc>
       </rect>
     </g>
     <g
@@ -22538,19 +22528,6 @@ roof_type = flat;</desc>
            id="desc9788-45-3-6-1-6-7-2-09-4-7-2-82-2-4-2-6-7-0-4-6">type = vehicle; key = deco_car2_white.vehicle;</desc>
       </rect>
       <rect
-         transform="matrix(0.47845581,0.87811163,-0.87811163,0.47845581,0,0)"
-         inkscape:label=""
-         y="-721.16895"
-         x="1453.3822"
-         height="7.3961515"
-         width="3.982286"
-         id="spawn1-70-1-4-9-17-2-25-2-6-1-9"
-         style="fill:#ffd5d5;fill-opacity:1;stroke:#ff00ff;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:11.99999985, 11.99999985;stroke-dashoffset:4.59999986;display:inline;enable-background:new">
-        <desc
-           id="desc7082-9-7-0-4-4-3-3-9-2-1-8">type = vehicle;
-key = mobile_armory.vehicle;</desc>
-      </rect>
-      <rect
          inkscape:label="#spawnrect10748"
          y="-1519.6591"
          x="539.15106"
@@ -22562,19 +22539,6 @@ key = mobile_armory.vehicle;</desc>
         <desc
            id="desc5002-4-7-8-98-7">type = vehicle;
 key = special_crate6.vehicle;</desc>
-      </rect>
-      <rect
-         transform="matrix(0.96463864,-0.26357599,0.26357599,0.96463864,0,0)"
-         inkscape:label=""
-         y="1159.4611"
-         x="432.40964"
-         height="7.3961515"
-         width="3.982286"
-         id="spawn1-70-1-4-9-17-2-25-2-6-1-9-1-4"
-         style="fill:#ffd5d5;fill-opacity:1;stroke:#ff00ff;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:12, 12;stroke-dashoffset:4.59999994;display:inline;enable-background:new">
-        <desc
-           id="desc7082-9-7-0-4-4-3-3-9-2-1-8-7-8">type = vehicle;
-key = mobile_armory.vehicle;</desc>
       </rect>
       <rect
          transform="matrix(0.00111912,-0.99999937,0.99999937,0.00111912,0,0)"
@@ -22663,6 +22627,50 @@ walkable = 1; </desc>
            id="title33916-4-7-5-9">armory</title>
         <desc
            id="desc6851-7-7-1-6-4-05">template = armory;</desc>
+      </rect>
+      <rect
+         inkscape:label=""
+         y="-1115.5265"
+         x="509.45117"
+         height="4"
+         width="4"
+         id="item_supply2-2-4-11-6-4-2-2"
+         style="display:inline;fill:#de8787;fill-opacity:1;enable-background:new"
+         transform="rotate(118.69103)"
+         inkscape:transform-center-x="2.6376188"
+         inkscape:transform-center-y="5.2588484">
+        <desc
+           id="desc33018-1-8-2-4">type = weapon_rack;</desc>
+      </rect>
+      <rect
+         style="display:inline;fill:#69c044;fill-opacity:1;stroke:#000000;stroke-width:1.20000005;enable-background:new"
+         id="mesh3-9-9-5-4-6-2-55-9-0-1-3-7-8"
+         width="7.1999998"
+         height="9.6000004"
+         x="1127.2378"
+         y="460.71567"
+         inkscape:label="#mesh"
+         transform="rotate(30.744331)"
+         inkscape:transform-center-x="-0.082297843"
+         inkscape:transform-center-y="0.15792756">
+        <title
+           id="title33916-4-7-5-9-3-3">armory</title>
+        <desc
+           id="desc6851-7-7-1-6-4-05-7-9">template = armory;</desc>
+      </rect>
+      <rect
+         transform="rotate(-160.73088)"
+         inkscape:label=""
+         y="-402.02521"
+         x="-1477.5465"
+         height="6.6684999"
+         width="5.7888808"
+         id="spawn4_4-9-2"
+         style="display:inline;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:4.0000009, 4.0000009;stroke-dashoffset:7.00000191;stroke-opacity:1;enable-background:new"
+         inkscape:transform-center-x="0.34203044"
+         inkscape:transform-center-y="-0.14203432">
+        <desc
+           id="desc9788-45-3-6-1-6-7-2-09-4-7-2-82-2-4-4-2-4-7-5-1-5-4-3-6-4-3-2">type = vehicle; key = deco_pickup_red.vehicle;</desc>
       </rect>
     </g>
     <g
@@ -24075,6 +24083,36 @@ walkable = 1; </desc>
            id="title33916-4-7-5-9-3">armory</title>
         <desc
            id="desc6851-7-7-1-6-4-05-7">template = armory;</desc>
+      </rect>
+      <rect
+         inkscape:label=""
+         y="1407.1416"
+         x="793.36847"
+         height="4"
+         width="4"
+         id="item_supply2-2-4-11-6-4-2-7"
+         style="display:inline;fill:#de8787;fill-opacity:1;enable-background:new"
+         transform="rotate(-25.153007)"
+         inkscape:transform-center-x="-5.2322"
+         inkscape:transform-center-y="-2.6899075">
+        <desc
+           id="desc33018-1-8-2-9">type = weapon_rack;</desc>
+      </rect>
+      <rect
+         style="display:inline;fill:#69c044;fill-opacity:1;stroke:#000000;stroke-width:1.20000005;enable-background:new"
+         id="mesh3-9-9-5-4-6-2-55-9-0-1-3-7-3"
+         width="7.1999998"
+         height="9.6000004"
+         x="-1383.6381"
+         y="834.83606"
+         inkscape:label="#mesh"
+         transform="rotate(-113.0997)"
+         inkscape:transform-center-x="-0.026743116"
+         inkscape:transform-center-y="-0.17598694">
+        <title
+           id="title33916-4-7-5-9-3-8">armory</title>
+        <desc
+           id="desc6851-7-7-1-6-4-05-7-0">template = armory;</desc>
       </rect>
     </g>
   </g>

--- a/package_config.xml
+++ b/package_config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package
   name="Search and Destroy"
-  description="Plant the bomb or find the bomb. You'll work it out."
+  description="PVP: Demolition | Hostage Rescue | VIP Assassination"
   show_in_campaign_menu="1"
   campaign_entry_script="start_snd.as"
   image="snd_campaign.png">

--- a/scripts/common/hitbox_handler.as
+++ b/scripts/common/hitbox_handler.as
@@ -23,7 +23,7 @@ class HitboxHandler : Tracker {
 	protected bool m_started = false;
 
 	protected float TRACKED_CHAR_CHECK_TIME = 5.0; 	// how often to check the list of tracked characters
-	protected float nextCheck = 5.0;				// countdown timer start value (allow some time to get ready for tracking)
+	protected float nextCheck = 15.0;				// countdown timer start value (allow some time to get ready for tracking)
 
 	// ----------------------------------------------------
 	HitboxHandler(GameModeSND@ metagame, string stageType) {
@@ -35,6 +35,7 @@ class HitboxHandler : Tracker {
 	void start() {
 		_log("** SND: starting HitboxHandler tracker", 1);
 		m_trackedTriggerAreas.clear();
+		m_trackedCharIds.clear();
 		determineTriggerAreasList();
 		m_started = true;
 	}
@@ -162,7 +163,7 @@ class HitboxHandler : Tracker {
 		_log("** SND: Activating Hitbox tracking for character id:" + charId, 1);
 		m_trackedCharIds.insertLast(charId);
 		// remove any existing associations (char : hitbox)
-		clearTriggerAreaAssociations(m_metagame, "character", charId, m_trackedTriggerAreas);
+			//clearTriggerAreaAssociations(m_metagame, "character", charId, m_trackedTriggerAreas);
 		// get current Trigger Areas list and associate charId with each trigger area in the list
 		const array<const XmlElement@> list = getTriggerAreasList();
 		if (list !is null) {

--- a/scripts/common/hitbox_handler.as
+++ b/scripts/common/hitbox_handler.as
@@ -163,7 +163,7 @@ class HitboxHandler : Tracker {
 		_log("** SND: Activating Hitbox tracking for character id:" + charId, 1);
 		m_trackedCharIds.insertLast(charId);
 		// remove any existing associations (char : hitbox)
-			//clearTriggerAreaAssociations(m_metagame, "character", charId, m_trackedTriggerAreas);
+		clearTriggerAreaAssociations(m_metagame, "character", charId, m_trackedTriggerAreas);
 		// get current Trigger Areas list and associate charId with each trigger area in the list
 		const array<const XmlElement@> list = getTriggerAreasList();
 		if (list !is null) {

--- a/scripts/common/hitbox_handler.as
+++ b/scripts/common/hitbox_handler.as
@@ -18,12 +18,13 @@ class HitboxHandler : Tracker {
 
 	protected array<const XmlElement@> m_triggerAreas;
 	protected array<string> m_trackedTriggerAreas;
+
 	protected array<int> m_trackedCharIds;
+	protected float TRACKED_CHAR_CHECK_TIME = 5.0; 	// how often to check the metagame's list of tracked characters
+	protected float nextCheck = 15.0;				// countdown timer start value (allow some time to get ready for tracking)
+
 
 	protected bool m_started = false;
-
-	protected float TRACKED_CHAR_CHECK_TIME = 5.0; 	// how often to check the list of tracked characters
-	protected float nextCheck = 15.0;				// countdown timer start value (allow some time to get ready for tracking)
 
 	// ----------------------------------------------------
 	HitboxHandler(GameModeSND@ metagame, string stageType) {
@@ -37,6 +38,7 @@ class HitboxHandler : Tracker {
 		m_trackedTriggerAreas.clear();
 		m_trackedCharIds.clear();
 		determineTriggerAreasList();
+		m_metagame.setNumExtracted(0);
 		m_started = true;
 	}
 
@@ -321,8 +323,8 @@ class HitboxHandler : Tracker {
 	// --------------------------------------------
 	void update(float time) {
 
+		// observe the metagame's trackedCharIds array and maintain a copy of it just for this tracker
 		nextCheck -= time;
-
 		if (nextCheck <= 0.0) {
 			array<int> ids = m_metagame.getTrackedCharIds();
 			for (uint i = 0; i < ids.size(); ++i) {

--- a/scripts/gamemodes/assassination/as_substage.as
+++ b/scripts/gamemodes/assassination/as_substage.as
@@ -40,13 +40,13 @@ class Assassination : SubStage {
 		@m_playerTracker = PlayerTracker(m_metagame);
 		addTracker(m_playerTracker);
 
-		// prepare vip and extraction points
-		@m_hitboxHandler = HitboxHandler(m_metagame, "as");
-		addTracker(m_hitboxHandler);
-
 		// track the vip
 		@m_vipTracker = VIPTracker(m_metagame);
 		addTracker(m_vipTracker);
+
+		// prepare vip and extraction points
+		@m_hitboxHandler = HitboxHandler(m_metagame, "as");
+		addTracker(m_hitboxHandler);
 
 		SubStage::startMatch();
 
@@ -76,6 +76,7 @@ class Assassination : SubStage {
 			// in CS (vip rescue game mode), Terrorists win if clock runs out.
 			winner = winCondition.getIntAttribute("faction_id");
 			if (winner == -1) {
+				_log("** SND: AS stage, T win by timeout", 1);
 				winner = 1; // terrorists
 			}
 		} else {

--- a/scripts/gamemodes/assassination/as_substage.as
+++ b/scripts/gamemodes/assassination/as_substage.as
@@ -40,13 +40,13 @@ class Assassination : SubStage {
 		@m_playerTracker = PlayerTracker(m_metagame);
 		addTracker(m_playerTracker);
 
-		// track the vip
-		@m_vipTracker = VIPTracker(m_metagame);
-		addTracker(m_vipTracker);
-
 		// prepare vip and extraction points
 		@m_hitboxHandler = HitboxHandler(m_metagame, "as");
 		addTracker(m_hitboxHandler);
+
+		// track the vip
+		@m_vipTracker = VIPTracker(m_metagame);
+		addTracker(m_vipTracker);
 
 		SubStage::startMatch();
 

--- a/scripts/gamemodes/assassination/vip_tracker.as
+++ b/scripts/gamemodes/assassination/vip_tracker.as
@@ -176,29 +176,32 @@ class VIPTracker : Tracker {
 		m_metagame.removeTrackedCharId(vipCharId);
 
 		const XmlElement@ killer = event.getFirstElementByTagName("killer");
-		int pKillerId = killer.getIntAttribute("player_id");
-		int killerCharId = killer.getIntAttribute("id");
-		if (pKillerId >= 0) {
-			if (killer.getIntAttribute("faction_id") == target.getIntAttribute("faction_id")) {
-				// teamkill, penalise!
-				string penaliseVIPTeamKiller = "<command class='rp_reward' character_id='" + killerCharId + "' reward='-3500'></command>";
-				m_metagame.getComms().send(penaliseVIPTeamKiller);
-				m_metagame.addRP(killerCharId, -3500);
-			} else {
-				// Terrorist / enemy killed VIP. Winner
-				string rewardVIPKiller = "<command class='rp_reward' character_id='" + killerCharId + "' reward='500'></command>";
-				m_metagame.getComms().send(rewardVIPKiller);
-				m_metagame.addRP(killerCharId, 500);
-				array<int> tIds = m_metagame.getFactionPlayerCharacterIds(killer.getIntAttribute("faction_id"));
-				for (uint i = 0; i < tIds.length() ; ++i) {
-					string vipKilledReward = "<command class='rp_reward' character_id='" + tIds[i] + "' reward='" + 2000 + "'></command>";
-					m_metagame.getComms().send(vipKilledReward);
-					m_metagame.addRP(tIds[i], 2000);
+		if (killer !is null) {
+			int pKillerId = killer.getIntAttribute("player_id");
+			int killerCharId = killer.getIntAttribute("id");
+			if (pKillerId >= 0) {
+				if (killer.getIntAttribute("faction_id") == target.getIntAttribute("faction_id")) {
+					// teamkill, penalise!
+					string penaliseVIPTeamKiller = "<command class='rp_reward' character_id='" + killerCharId + "' reward='-3500'></command>";
+					m_metagame.getComms().send(penaliseVIPTeamKiller);
+					m_metagame.addRP(killerCharId, -3500);
+				} else {
+					// Terrorist / enemy killed VIP. Winner
+					string rewardVIPKiller = "<command class='rp_reward' character_id='" + killerCharId + "' reward='500'></command>";
+					m_metagame.getComms().send(rewardVIPKiller);
+					m_metagame.addRP(killerCharId, 500);
+					array<int> tIds = m_metagame.getFactionPlayerCharacterIds(killer.getIntAttribute("faction_id"));
+					for (uint i = 0; i < tIds.length() ; ++i) {
+						string vipKilledReward = "<command class='rp_reward' character_id='" + tIds[i] + "' reward='" + 2000 + "'></command>";
+						m_metagame.getComms().send(vipKilledReward);
+						m_metagame.addRP(tIds[i], 2000);
+					}
 				}
+				winRound(-(target.getIntAttribute("faction_id")) +1);
+				sendFactionMessage(m_metagame, -1, "The VIP has been assassinated!");
 			}
-			winRound(-(target.getIntAttribute("faction_id")) +1);
 		}
-		sendFactionMessage(m_metagame, -1, "The VIP has been assassinated!");
+		// else allow handleCharacterDieEvent to manage it.
 	}
 
 	// died (confirm otherwise)

--- a/scripts/gamemodes/assassination/vip_tracker.as
+++ b/scripts/gamemodes/assassination/vip_tracker.as
@@ -69,6 +69,7 @@ class VIPTracker : Tracker {
 			string spawnCommand = "<command class='create_instance' instance_class='character' faction_id='0' position='" + pos.toString() + "' instance_key='vip' /></command>";
 			m_metagame.getComms().send(spawnCommand);
 			playSound(m_metagame, "vip.wav", 0);
+			markVIPPosition(pos.toString());
 			inPlay = true;
 			_log("** SND: VIP has spawned near player " + charId + " at position: " + playerPos, 1);
 		}
@@ -93,8 +94,6 @@ class VIPTracker : Tracker {
 			// marks the current location of the VIP on screen, screen-edge, and/or map overlay
 			// by default, only counter terrorists (faction 0) are alerted to the VIP's location. Pass a faction_id as the int to override
 			_log("** SND: Marking location of vip", 1);
-
-			// mark for friendlies only
 			string vipMarkerCmd = "<command class='set_marker' id='8008' enabled='" + (enabled ? 1 : 0) + "' atlas_index='4' faction_id='" + faction + "' text='' position='" + position + "' color='#FFFFFF' size='1.0' show_in_game_view='1' show_in_map_view='1' show_at_screen_edge='1' />";
 			m_metagame.getComms().send(vipMarkerCmd);
 			_log("** SND: Updated vip location marker!", 1);

--- a/scripts/gamemodes/bomb_defusal/bomb_tracker.as
+++ b/scripts/gamemodes/bomb_defusal/bomb_tracker.as
@@ -19,7 +19,7 @@ class BombTracker : Tracker {
 	protected float BOMB_POS_UPDATE_TIME = 5.0;	// how often the position of the bomb is checked
 	protected float bombPosUpdateTimer = 0.0;	// the time remaining until the next update
 
-	protected float bombTimer = 45.0;	// when bombIsArmed, the timer starts.
+	protected float bombTimer = 60.0;	// when bombIsArmed, the timer starts.
 
 	// --------------------------------------------
 	BombTracker(GameModeSND@ metagame) {

--- a/scripts/gamemodes/bomb_defusal/bomb_tracker.as
+++ b/scripts/gamemodes/bomb_defusal/bomb_tracker.as
@@ -101,9 +101,12 @@ class BombTracker : Tracker {
 					array<const XmlElement@> pInv = playerInv.getElementsByTagName("item");
 					// element '1' is the secondary weapon slot, the only place the bomb could be and not be detected by events.
 					if (pInv[1].getStringAttribute("key") == "bomb.weapon") {
-						bombCarrier = playerCharId;
-						bombFaction = players[i].getIntAttribute("faction_id");
-						break;
+						if (pInv[1].getIntAttribute("amount") > 0) {
+							bombCarrier = playerCharId;
+							bombFaction = players[i].getIntAttribute("faction_id");
+							_log("** SND: Character " + bombCarrier + " has the bomb equipped.", 1);
+							break;
+						}
 					}
 				}
 				if (bombCarrier == -1) {
@@ -115,7 +118,6 @@ class BombTracker : Tracker {
 			const XmlElement@ bomberLoc = getCharacterInfo(m_metagame, bombCarrier);
 			string position = bomberLoc.getStringAttribute("position");
 			bombPosition = position;
-			_log("** SND: Character " + bombCarrier + " is carrying the bomb at " + bombPosition + ".", 1);
 			return bombPosition;
 		} else {
 			_log("** SND: can't locate bomb carrier or bomb :-(", 1);
@@ -286,6 +288,7 @@ class BombTracker : Tracker {
 					_log("** SND: Bomb (" + itemKey + ") dropped onto ground", 1);
 					// bad idea! Now everyone gets to find out where the bomb is
 					bombCarrier = -1;
+					sendFactionMessage(m_metagame, -1, "BOMB DROPPED. LOCATION COMPROMISED!");
 					markBombPosition(bombPosition);
 					holdBombUpdate = 3;
 					break;

--- a/scripts/gamemodes/bomb_defusal/bomb_tracker.as
+++ b/scripts/gamemodes/bomb_defusal/bomb_tracker.as
@@ -11,7 +11,8 @@ class BombTracker : Tracker {
 	protected bool m_started = false;
 	protected bool bombIsArmed = false; // a correctly planted and located bomb is automatically armed
 	protected bool bombInPlay = false;  // should only ever be 1 bomb in play
-	protected int bombCarrier = -1;	    // and one (or no) character_id carrying it
+	protected int holdBombUpdate = -1;	// when dropped on ground, hold off position updates for this many update cycles
+	protected int bombCarrier = -1;	    // the character_id of who is carrying the bomb
 	protected int bombFaction = -1;     // the faction_id of the current bombCarrier
 	protected int bombOwnerFaction = -1;// the faction_id of the faction who start the round with the bomb
 	protected string bombPosition = ""; // xxx.xxx yyy.yyy zzz.zzz
@@ -87,6 +88,7 @@ class BombTracker : Tracker {
 			// gets and returns current location of the bombCarrier
 			// relies on bombCarrier int to be updated when the bomb changes hands, is dropped, etc.
 			// see handleItemDropEvent method
+
 			if (bombCarrier == -1) {
 				_log("** SND: nobody had the bomb at last check. It's either on the ground or someone has it equipped", 1);
 				// confirm noone has picked up the bomb directly to secondary weapon slot, which is not tracked
@@ -99,23 +101,25 @@ class BombTracker : Tracker {
 					array<const XmlElement@> pInv = playerInv.getElementsByTagName("item");
 					// element '1' is the secondary weapon slot, the only place the bomb could be and not be detected by events.
 					if (pInv[1].getStringAttribute("key") == "bomb.weapon") {
-						_log("** SND: Found who has the bomb. Updating bomb holder and location info", 1);
 						bombCarrier = playerCharId;
 						bombFaction = players[i].getIntAttribute("faction_id");
 						break;
 					}
 				}
-				_log("** SND: noone has the bomb, must be on the ground...", 1);
-				return bombPosition; // unchanged
-			} else {
-				const XmlElement@ bomberLoc = getCharacterInfo(m_metagame, bombCarrier);
-				string position = bomberLoc.getStringAttribute("position");
-				bombPosition = position;
-				return position;
+				if (bombCarrier == -1) {
+					_log("** SND: noone has the bomb, must be on the ground still...", 1);
+					return bombPosition;
+				}
 			}
+			// We know who has the bomb, provide that character's position
+			const XmlElement@ bomberLoc = getCharacterInfo(m_metagame, bombCarrier);
+			string position = bomberLoc.getStringAttribute("position");
+			bombPosition = position;
+			_log("** SND: Character " + bombCarrier + " is carrying the bomb at " + bombPosition + ".", 1);
+			return bombPosition;
 		} else {
 			_log("** SND: can't locate bomb carrier or bomb :-(", 1);
-			return "0 0 0";
+			return "0 0 0"; // return a string out of necessity. This method will run again soon and hopefully will find the bomb then :-)
 		}
 	}
 
@@ -213,6 +217,7 @@ class BombTracker : Tracker {
 				// Some goofball planted the bomb in the wrong place. Give them another chance...
 				addItemToBackpack("bomb.weapon", bombCarrier);
 				// probably worth berating the player via notice / message as well.
+				sendFactionMessage(m_metagame, bombFaction, "You can't plant the bomb there...");
 			}
 		} else if (vehKey == "bomb_defused.vehicle") {
 			// sanity / no point checking if bomb hasn't been planted
@@ -281,14 +286,15 @@ class BombTracker : Tracker {
 					_log("** SND: Bomb (" + itemKey + ") dropped onto ground", 1);
 					// bad idea! Now everyone gets to find out where the bomb is
 					bombCarrier = -1;
-					markBombPosition(getBombPosition());
+					markBombPosition(bombPosition);
+					holdBombUpdate = 3;
 					break;
 				case 1:
 					_log("** SND: Bomb (" + itemKey + ") sold to armoury", 1);
 					addItemToBackpack("bomb.weapon", bombCarrier);
 				case 2:
 					_log("** SND: Bomb dropped into backpack", 1);
-					markBombPosition(getBombPosition(), bombFaction);
+					markBombPosition(bombPosition, bombFaction);
 					break;
 				default: // shouldn't ever get here, but sanity
 					_log("** SND: WARNING! Bomb was dropped in target_container_type_id: " + event.getIntAttribute("target_container_type_id") + ". Not tracked!", 1);
@@ -321,6 +327,7 @@ class BombTracker : Tracker {
 			}
 		}
 		bombInPlay = false;
+		m_metagame.setTrackPlayerDeaths(false);
 		m_metagame.setMatchEndOverride(bombIsArmed); // false
 	}
 
@@ -351,7 +358,13 @@ class BombTracker : Tracker {
 		if (bombInPlay) {
 			bombPosUpdateTimer -= time;
 			if ((bombPosUpdateTimer < 0.0) && (!bombIsArmed)) {
-				markBombPosition(getBombPosition(), bombFaction);
+				// when the bomb is dropped on the ground, we tell all players where this occurred, for a few updates
+				if (holdBombUpdate > 0) {
+					_log("** SND: Bomb position update postponed for next " + holdBombUpdate + " checks", 1);
+					holdBombUpdate--;
+				} else {
+					markBombPosition(getBombPosition(), bombFaction);
+				}
 				bombPosUpdateTimer = BOMB_POS_UPDATE_TIME;
 			}
 			if (bombIsArmed) {

--- a/scripts/gamemodes/bomb_defusal/de_substage.as
+++ b/scripts/gamemodes/bomb_defusal/de_substage.as
@@ -95,6 +95,7 @@ class BombDefusal : SubStage {
 			// in CS (demolition game mode), Counter Terrorists win if clock runs out and bomb has not been planted.
 			winner = winCondition.getIntAttribute("faction_id");
 			if (winner == -1) {
+				_log("** SND: DE stage, CT win by timeout", 1);
 				winner = 0; // counter terrorists
 			}
 		} else {

--- a/scripts/gamemodes/hostage_rescue/hostage_tracker.as
+++ b/scripts/gamemodes/hostage_rescue/hostage_tracker.as
@@ -141,14 +141,16 @@ class HostageTracker : Tracker {
 			m_metagame.removeTrackedCharId(hostageCharId);
 			// penalise killer
 			const XmlElement@ killer = event.getFirstElementByTagName("killer");
-			int pKillerId = killer.getIntAttribute("player_id");
-			int killerCharId = killer.getIntAttribute("id");
-			if (pKillerId >= 0) {
-				string penaliseHostageKiller = "<command class='rp_reward' character_id='" + killerCharId + "' reward='-1200'></command>";
-				m_metagame.getComms().send(penaliseHostageKiller);
-				m_metagame.addRP(killerCharId, -1200);
-				sendFactionMessage(m_metagame, -1, "A hostage has been executed!");
-				m_metagame.addScore(killer.getIntAttribute("faction_id"), -1);
+			if (killer !is null) {
+				int pKillerId = killer.getIntAttribute("player_id");
+				int killerCharId = killer.getIntAttribute("id");
+				if (pKillerId >= 0) {
+					string penaliseHostageKiller = "<command class='rp_reward' character_id='" + killerCharId + "' reward='-1200'></command>";
+					m_metagame.getComms().send(penaliseHostageKiller);
+					m_metagame.addRP(killerCharId, -1200);
+					sendFactionMessage(m_metagame, -1, "A hostage has been executed!");
+					m_metagame.addScore(killer.getIntAttribute("faction_id"), -1);
+				}
 				array<Faction@> allFactions = m_metagame.getFactions();
 				for (uint i = 0; i < allFactions.length(); ++i) {
 					playSound(m_metagame, "hosdown.wav", i);

--- a/scripts/gamemodes/hostage_rescue/hr_substage.as
+++ b/scripts/gamemodes/hostage_rescue/hr_substage.as
@@ -65,13 +65,13 @@ class HostageRescue : SubStage {
 		@m_targetLocations = TargetLocations(m_metagame, "hr", positions);
 		addTracker(m_targetLocations);
 
-		// track the hostages
-		@m_hostageTracker = HostageTracker(m_metagame);
-		addTracker(m_hostageTracker);
-
 		// track hostage presence in extraction points
 		@m_hitboxHandler = HitboxHandler(m_metagame, "hr");
 		addTracker(m_hitboxHandler);
+
+		// track the hostages
+		@m_hostageTracker = HostageTracker(m_metagame);
+		addTracker(m_hostageTracker);
 
 		SubStage::startMatch();
 

--- a/scripts/gamemodes/hostage_rescue/hr_substage.as
+++ b/scripts/gamemodes/hostage_rescue/hr_substage.as
@@ -65,13 +65,13 @@ class HostageRescue : SubStage {
 		@m_targetLocations = TargetLocations(m_metagame, "hr", positions);
 		addTracker(m_targetLocations);
 
-		// track hostage presence in extraction points
-		@m_hitboxHandler = HitboxHandler(m_metagame, "hr");
-		addTracker(m_hitboxHandler);
-
 		// track the hostages
 		@m_hostageTracker = HostageTracker(m_metagame);
 		addTracker(m_hostageTracker);
+
+		// track hostage presence in extraction points
+		@m_hitboxHandler = HitboxHandler(m_metagame, "hr");
+		addTracker(m_hitboxHandler);
 
 		SubStage::startMatch();
 
@@ -101,6 +101,7 @@ class HostageRescue : SubStage {
 			// in CS (hostage rescue game mode), Terrorists win if clock runs out.
 			winner = winCondition.getIntAttribute("faction_id");
 			if (winner == -1) {
+				_log("** SND: HR stage, T win by timeout", 1);
 				winner = 1; // terrorists
 			}
 		} else {

--- a/scripts/snd/gamemode_snd.as
+++ b/scripts/snd/gamemode_snd.as
@@ -13,10 +13,10 @@ class GameModeSND : Metagame {
 	protected array<Faction@> m_factions;
 	protected dictionary pendingRPRewards = {}; // queue to store RP rewards to grant to players
 
-	array<Vector3> targetLocations;		// locations where bombs may be placed or hostages may start
-	array<Vector3> extractionPoints;	// locations that units must reach in order to escape
-	array<int> trackedCharIds;			// Ids of characters being tracked against collisions with hitboxes
-	int numExtracted = 0;				// the number of hostages safely rescued
+	protected array<Vector3> targetLocations;	// locations where bombs may be placed or hostages may start
+	protected array<Vector3> extractionPoints;	// locations that units must reach in order to escape
+	protected array<int> trackedCharIds;		// Ids of characters being tracked against collisions with hitboxes
+	protected int numExtracted = 0;				// the number of hostages safely rescued
 
 	protected bool trackPlayerDeaths = true;
 

--- a/scripts/snd/player_manager.as
+++ b/scripts/snd/player_manager.as
@@ -338,31 +338,33 @@ class PlayerTracker : Tracker {
 		const XmlElement@ playerKiller = event.getFirstElementByTagName("killer");
 		const XmlElement@ playerTarget = event.getFirstElementByTagName("target");
 
-		int factionId = playerKiller.getIntAttribute("faction_id");
-		int pKillerId = playerKiller.getIntAttribute("player_id");
-		int pKillerCharId = playerKiller.getIntAttribute("character_id");
-		_log("** SND: Player scores: " + playerKiller.getStringAttribute("name") + ", faction " + factionId);
+		if (playerKiller !is null) {
+			int factionId = playerKiller.getIntAttribute("faction_id");
+			int pKillerId = playerKiller.getIntAttribute("player_id");
+			int pKillerCharId = playerKiller.getIntAttribute("character_id");
+			_log("** SND: Player scores: " + playerKiller.getStringAttribute("name") + ", faction " + factionId);
 
-		if (playerKiller.getStringAttribute("profile_hash") == playerTarget.getStringAttribute("profile_hash")) {
-			// killed self
-			_log("** SND: Player " + pKillerId + " committed suicide. Decrement score", 1);
-			// no cash penalty for suicide, just score
-			m_metagame.addScore(factionId, -1);
-		} else if (playerKiller.getIntAttribute("faction_id") == playerTarget.getIntAttribute("faction_id")) {
-			// killed teammate
-			_log("** SND: Player " + pKillerId+ " killed a friendly unit. Cash penalty and decrement score", 1);
-			string penaliseTeamKills = "<command class='rp_reward' character_id='" + pKillerCharId + "' reward='-3300'></command>";
-			m_metagame.getComms().send(penaliseTeamKills);
-			m_metagame.addRP(pKillerCharId, -3300);
-			m_metagame.addScore(factionId, -1);
-		} else if (playerKiller.getIntAttribute("player_id") != playerTarget.getIntAttribute("player_id")) {
-			// killed player on other team
-			_log("** SND: Player " + pKillerId + " killed an enemy unit. Cash reward and increase score", 1);
-			playSound(m_metagame, "enemydown.wav", factionId);
-			string rewardEnemyKills = "<command class='rp_reward' character_id='" + pKillerCharId + "' reward='300'></command>";
-			m_metagame.getComms().send(rewardEnemyKills);
-			m_metagame.addRP(pKillerCharId, 300);
-			m_metagame.addScore(factionId, 2);
+			if (playerKiller.getStringAttribute("profile_hash") == playerTarget.getStringAttribute("profile_hash")) {
+				// killed self
+				_log("** SND: Player " + pKillerId + " committed suicide. Decrement score", 1);
+				// no cash penalty for suicide, just score
+				m_metagame.addScore(factionId, -1);
+			} else if (playerKiller.getIntAttribute("faction_id") == playerTarget.getIntAttribute("faction_id")) {
+				// killed teammate
+				_log("** SND: Player " + pKillerId+ " killed a friendly unit. Cash penalty and decrement score", 1);
+				string penaliseTeamKills = "<command class='rp_reward' character_id='" + pKillerCharId + "' reward='-3300'></command>";
+				m_metagame.getComms().send(penaliseTeamKills);
+				m_metagame.addRP(pKillerCharId, -3300);
+				m_metagame.addScore(factionId, -1);
+			} else if (playerKiller.getIntAttribute("player_id") != playerTarget.getIntAttribute("player_id")) {
+				// killed player on other team
+				_log("** SND: Player " + pKillerId + " killed an enemy unit. Cash reward and increase score", 1);
+				playSound(m_metagame, "enemydown.wav", factionId);
+				string rewardEnemyKills = "<command class='rp_reward' character_id='" + pKillerCharId + "' reward='300'></command>";
+				m_metagame.getComms().send(rewardEnemyKills);
+				m_metagame.addRP(pKillerCharId, 300);
+				m_metagame.addScore(factionId, 2);
+			}
 		}
 	}
 

--- a/scripts/snd/player_manager.as
+++ b/scripts/snd/player_manager.as
@@ -390,6 +390,11 @@ class PlayerTracker : Tracker {
 		// skip die event processing if disconnected
 		if (event.getBoolAttribute("combat") == false) return;
 
+		// if not tracking player deaths (e.g. round ended), bail
+		if (!m_metagame.getTrackPlayerDeaths()) {
+			return;
+		}
+
 		// enforce no respawning (1 life per round)
 		array<Faction@> allFactions = m_metagame.getFactions();
 		for (uint i = 0; i < allFactions.length(); ++i) {
@@ -547,6 +552,11 @@ class PlayerTracker : Tracker {
 				// it has, no attrition ending allowed for this round, bail.
 				return;
 			}
+
+			// otherwise, we have come to a win/lose event.
+			// stop tracking further player deaths
+			m_metagame.setTrackPlayerDeaths(false);
+
 			_log("** SND: faction " + faction + " has run out of live players. Lose round!", 1);
 			string winLoseCmd = "";
 			array<Faction@> allFactions = m_metagame.getFactions();

--- a/scripts/snd/substage_snd.as
+++ b/scripts/snd/substage_snd.as
@@ -53,7 +53,13 @@ abstract class SubStage : Tracker {
 
 		sendFactionMessage(m_metagame, -1, m_displayName + " starts!");
 
-		// clear game's score display
+		// reset the list of tracked character Ids
+		array<int> trackedCharIds = m_metagame.getTrackedCharIds();
+		for (uint i = 0; i < trackedCharIds.length; ++i) {
+			m_metagame.removeTrackedCharId(trackedCharIds[i]);
+		}
+
+		// reset game's score display
 		m_metagame.resetScores();
 		_log("** SND: Scoreboard Reset", 1);
 		m_winner = -1;

--- a/weapons/bomb.projectile
+++ b/weapons/bomb.projectile
@@ -2,7 +2,7 @@
 <projectile class="grenade" name="bomb" key="bomb.projectile" slot="0" on_ground_up="0 1 0" can_be_disarmed="0" can_be_detected_by_driver="1" time_to_live_out_in_the_open="26.0" drop_count_factor_on_death="0.0">
 
 <!--
-    this is the actual explosion of the bomb if it has not been disarmed within bombTimer (30) seconds.
+    this is the actual explosion of the bomb if it has not been disarmed within bombTimer seconds (see bomb_tracker.as).
     this projectile exists solely to create an explosion where the bomb was placed.
 -->
 

--- a/weapons/bomb_armed.projectile
+++ b/weapons/bomb_armed.projectile
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<projectile class="grenade" name="" key="bomb_armed.projectile" slot="0" on_ground_up="0 1 0" can_be_disarmed="0" can_be_detected_by_driver="1" time_to_live_out_in_the_open="26.0" drop_count_factor_on_death="0.0">
+<projectile class="grenade" name="" key="bomb_armed.projectile" slot="0" on_ground_up="0 1 0" can_be_disarmed="0" can_be_detected_by_driver="1" time_to_live_out_in_the_open="46.0" drop_count_factor_on_death="0.0">
 
 <!--
     this is a visual representation of the bomb to aid the defusing team in locating
@@ -7,7 +7,7 @@
 -->
 
     <collision class="sticky" />
-    <trigger class="time" time_to_live="26.0"/>
+    <trigger class="time" time_to_live="46.0"/>
     <result class="blast" radius="0.0" damage="0.0" push="0.0" decal="1" character_state="none" />
 
     <rotation class="random" />

--- a/weapons/m249.weapon
+++ b/weapons/m249.weapon
@@ -15,14 +15,18 @@
     projectile_speed="100.0"
   />
 
-    <animation key="recoil" ref="12" />
-    <animation key="recoil" ref="13" />
-    <animation key="recoil" ref="14" />
+    <animation state_key="recoil" animation_key="recoil, hip fire" />
+    <animation state_key="recoil" animation_key="recoil2, hip fire" />
+    <animation state_key="recoil" animation_key="recoil3, hip fire" />
+    <animation key="recoil" stance_key="over_wall" ref="12" />
+    <animation key="recoil" stance_key="over_wall" ref="13" />
+    <animation key="recoil" stance_key="over_wall" ref="14" />
+    <animation state_key="hold" animation_key="hold, lmg" />
     <animation key="reload" ref="33" />
-    <animation key="hold" ref="32" />
     <animation key="hold_on_wall" ref="1" />
-    <animation state_key="walking" animation_key="walking, heavy weapon" />
-    <animation state_key="walking_backwards" animation_key="walking backwards, heavy weapon" />
+    <animation state_key="walking" animation_key="walking, hip fire" />
+    <animation state_key="crouching" animation_key="crouch, hold, hip fire" />
+    <animation state_key="crouch_moving" animation_key="crouching forwards, hip fire" />
 
     <sound key="fire" fileref="m249_01.wav" pitch_variety="0.06" volume="0.7" />
     <sound key="magazine_out" fileref="m249_boxout.wav" />
@@ -39,7 +43,7 @@
     <stance state_key="prone_moving" accuracy="0.1" />
 
     <stance state_key="standing" accuracy="0.45" />
-    <stance state_key="crouching" accuracy="0.55" />
+    <stance state_key="crouching" accuracy="0.65" />
     <stance state_key="prone" accuracy="0.95" />
     <stance state_key="over_wall" accuracy="0.9" />
 


### PR DESCRIPTION
* Bugfix: Indirect deaths (e.g. run over by driverless vehicle) are now handled without causing a script error
* Bugfix: M249 can now be fired standing, crouching, or prone without seeming to jam on occasion
* Map fix: Humvees and mobile armouries replaced with static vehicles / objects. No more free rides / escapes for AI units :-P
* Balance tweak: An armed / planted bomb now takes 60 seconds to detonate (up from 45)
* Vest tweak: The 'wounded' state has been replaced with a stunned effect. Characters becoming wounded is not applicable in SND because medkits are not available.

0.11.1
* Bugfix: DE stages now correctly wait for a planted bomb to detonate or be defused (or the round timer expires) before ending the round, event if there are no surviving terrorist units.

0.11.0
* All HUD icons for weapons and equipment updated.